### PR TITLE
Add PDO connection and database initialization script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+db/database.sqlite

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # karnaval
+
+## Database setup
+
+Run `php db/init_db.php` to create the SQLite database at `db/database.sqlite` with the tables and sample data defined in `db/schema.sql`.
+
+To use MySQL instead, set the environment variables `DB_TYPE=mysql`, `DB_HOST`, `DB_NAME`, `DB_USER`, and `DB_PASS` before running the script.

--- a/db/init_db.php
+++ b/db/init_db.php
@@ -1,0 +1,12 @@
+<?php
+require_once __DIR__ . '/../db_connect.php';
+
+try {
+    $pdo = getDbConnection();
+    $schema = file_get_contents(__DIR__ . '/schema.sql');
+    $pdo->exec($schema);
+    echo "Database initialized successfully." . PHP_EOL;
+} catch (PDOException $e) {
+    fwrite(STDERR, "Database initialization failed: " . $e->getMessage() . PHP_EOL);
+    exit(1);
+}

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,42 @@
+-- Schema definition for categories, products, product_options
+DROP TABLE IF EXISTS product_options;
+DROP TABLE IF EXISTS products;
+DROP TABLE IF EXISTS categories;
+
+CREATE TABLE categories (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL
+);
+
+CREATE TABLE products (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    category_id INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    price REAL NOT NULL,
+    description TEXT,
+    FOREIGN KEY (category_id) REFERENCES categories(id)
+);
+
+CREATE TABLE product_options (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    product_id INTEGER NOT NULL,
+    option_name TEXT NOT NULL,
+    option_value TEXT NOT NULL,
+    FOREIGN KEY (product_id) REFERENCES products(id)
+);
+
+-- Sample data
+INSERT INTO categories (name) VALUES ('Electronics');
+INSERT INTO categories (name) VALUES ('Books');
+
+INSERT INTO products (category_id, name, price, description) VALUES
+ (1, 'Smartphone', 699.99, 'Latest model smartphone'),
+ (1, 'Laptop', 1199.50, 'Powerful laptop for professionals'),
+ (2, 'Novel', 19.99, 'Bestselling fiction book');
+
+INSERT INTO product_options (product_id, option_name, option_value) VALUES
+ (1, 'Color', 'Black'),
+ (1, 'Storage', '128GB'),
+ (2, 'RAM', '16GB'),
+ (2, 'Storage', '512GB'),
+ (3, 'Format', 'Hardcover');

--- a/db_connect.php
+++ b/db_connect.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Returns PDO database connection.
+ * Chooses SQLite by default or MySQL if DB_TYPE=mysql is set.
+ */
+function getDbConnection(): PDO
+{
+    $dbType = getenv('DB_TYPE') ?: 'sqlite';
+
+    $options = [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        PDO::ATTR_EMULATE_PREPARES => false,
+    ];
+
+    if ($dbType === 'mysql') {
+        $host = getenv('DB_HOST') ?: 'localhost';
+        $dbname = getenv('DB_NAME') ?: 'karnaval';
+        $user = getenv('DB_USER') ?: 'root';
+        $pass = getenv('DB_PASS') ?: '';
+        $dsn = "mysql:host={$host};dbname={$dbname};charset=utf8mb4";
+        return new PDO($dsn, $user, $pass, $options);
+    }
+
+    // Default SQLite connection
+    $path = __DIR__ . '/db/database.sqlite';
+    return new PDO('sqlite:' . $path, null, null, $options);
+}


### PR DESCRIPTION
## Summary
- implement secure PDO-based `getDbConnection` with MySQL or SQLite support
- add SQL schema and seed data for categories, products and product options
- provide `init_db.php` script and `.gitignore` to build the SQLite database instead of committing a binary

## Testing
- `php -l db_connect.php`
- `php -l db/init_db.php`
- `php db/init_db.php`
- `sqlite3 db/database.sqlite ".tables"`


------
https://chatgpt.com/codex/tasks/task_e_689835f31544832b8c2894b053eebdac