### PR TITLE
Add PDO connection and database initialization script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+db/database.sqlite

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # karnaval
+
+## Database setup
+
+Run `php db/init_db.php` to create the tables and sample data defined in `db/schema.sql`.
+
+By default the script connects to the MySQL database `gornichf_karnaval` using the user `gornichf_carnaval_user` and password `Vjybnjh1991` on `localhost`.
+
+Connection settings can be overridden by setting the environment variables `DB_TYPE`, `DB_HOST`, `DB_NAME`, `DB_USER`, and `DB_PASS`. Setting `DB_TYPE` to `sqlite` will instead create a local database at `db/database.sqlite`.

--- a/db/init_db.php
+++ b/db/init_db.php
@@ -1,0 +1,18 @@
+<?php
+require_once __DIR__ . '/../db_connect.php';
+
+try {
+    $pdo = getDbConnection();
+    $schema = file_get_contents(__DIR__ . '/schema.sql');
+    $schema = preg_replace('/--.*\n/', '', $schema);
+    $statements = array_filter(array_map('trim', explode(';', $schema)));
+    foreach ($statements as $statement) {
+        if ($statement !== '') {
+            $pdo->exec($statement);
+        }
+    }
+    echo "Database initialized successfully." . PHP_EOL;
+} catch (PDOException $e) {
+    fwrite(STDERR, "Database initialization failed: " . $e->getMessage() . PHP_EOL);
+    exit(1);
+}

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,41 @@
+-- Schema definition for categories, products, product_options
+DROP TABLE IF EXISTS product_options;
+DROP TABLE IF EXISTS products;
+DROP TABLE IF EXISTS categories;
+
+CREATE TABLE categories (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL
+);
+
+CREATE TABLE products (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    category_id INT NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    price DECIMAL(10,2) NOT NULL,
+    description TEXT,
+    FOREIGN KEY (category_id) REFERENCES categories(id)
+);
+
+CREATE TABLE product_options (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    product_id INT NOT NULL,
+    option_name VARCHAR(255) NOT NULL,
+    option_value VARCHAR(255) NOT NULL,
+    FOREIGN KEY (product_id) REFERENCES products(id)
+);
+
+-- Sample data
+INSERT INTO categories (name) VALUES ('Electronics'), ('Books');
+
+INSERT INTO products (category_id, name, price, description) VALUES
+ (1, 'Smartphone', 699.99, 'Latest model smartphone'),
+ (1, 'Laptop', 1199.50, 'Powerful laptop for professionals'),
+ (2, 'Novel', 19.99, 'Bestselling fiction book');
+
+INSERT INTO product_options (product_id, option_name, option_value) VALUES
+ (1, 'Color', 'Black'),
+ (1, 'Storage', '128GB'),
+ (2, 'RAM', '16GB'),
+ (2, 'Storage', '512GB'),
+ (3, 'Format', 'Hardcover');

--- a/db_connect.php
+++ b/db_connect.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Returns PDO database connection.
+ * Chooses SQLite by default or MySQL if DB_TYPE=mysql is set.
+ */
+function getDbConnection(): PDO
+{
+    $dbType = getenv('DB_TYPE') ?: 'mysql';
+
+    $options = [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        PDO::ATTR_EMULATE_PREPARES => false,
+    ];
+
+    if ($dbType === 'mysql') {
+        $host = getenv('DB_HOST') ?: 'localhost';
+        $dbname = getenv('DB_NAME') ?: 'gornichf_karnaval';
+        $user = getenv('DB_USER') ?: 'gornichf_carnaval_user';
+        $pass = getenv('DB_PASS') ?: 'Vjybnjh1991';
+        $dsn = "mysql:host={$host};dbname={$dbname};charset=utf8mb4";
+        return new PDO($dsn, $user, $pass, $options);
+    }
+
+    // Default SQLite connection
+    $path = __DIR__ . '/db/database.sqlite';
+    return new PDO('sqlite:' . $path, null, null, $options);
+}


### PR DESCRIPTION
## Summary
- default to MySQL using provided credentials and keep SQLite as optional fallback
- execute schema statements individually and switch to MySQL-friendly SQL syntax
- document default MySQL connection and configuration overrides

## Testing
- `php -l db_connect.php`
- `php -l db/init_db.php`
- `php db/init_db.php` (fails: SQLSTATE[HY000] [2002] No such file or directory)
- `sqlite3 db/database.sqlite ".tables"`


------
https://chatgpt.com/codex/tasks/task_e_689835f31544832b8c2894b053eebdac